### PR TITLE
Open scenes additively.

### DIFF
--- a/Assets/Plugins/Mooble/StaticAnalysis/CLI.cs
+++ b/Assets/Plugins/Mooble/StaticAnalysis/CLI.cs
@@ -93,7 +93,7 @@ namespace Mooble.StaticAnalysis {
         Scene scene;
 
         try {
-          scene = EditorSceneManager.OpenScene(arg);
+          scene = EditorSceneManager.OpenScene(arg, OpenSceneMode.Additive);
         } catch (System.ArgumentException) {
           continue;
         }


### PR DESCRIPTION
## Changes:
- Open scenes additively

## Comments:
This fixes a bug in the command line where if you passed in more than one scene, it would fail because the scene manager was not expecting to load more than one scene at a time.