### PR TITLE
11, getting object path in NoMissingComponentsViolation to show where…

### DIFF
--- a/Plugin/Mooble/StaticAnalysis/Violations/NoMissingComponentsViolation.cs
+++ b/Plugin/Mooble/StaticAnalysis/Violations/NoMissingComponentsViolation.cs
@@ -22,7 +22,7 @@ namespace Mooble.StaticAnalysis.Violation {
     public string FormatEditor() {
       return string.Format(
         "GameObject {0} has an undefined Component (missing script reference).",
-        Utility.FormatPrimaryObject(this.gameObject.name));
+        Utility.FormatPrimaryObject(Utility.FormatObjectPath(this.gameObject)));
     }
 
     public UnityEngine.Object GetObject() {


### PR DESCRIPTION
… a game object is located within a potencially big prefab

## Changes:
- Change 1.
- Change 2.

See the issue to get more information about this change.