### PR TITLE
Add NoImageWithMissingSprite rule and violation.

### DIFF
--- a/StaticAnalysis/Rules/NoImageWithMissingSprite.cs
+++ b/StaticAnalysis/Rules/NoImageWithMissingSprite.cs
@@ -1,0 +1,34 @@
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
+
+using Mooble.StaticAnalysis.Violation;
+using UnityEngine.UI;
+
+namespace Mooble.StaticAnalysis.Rules {
+  public class NoImageWithMissingSprite : Rule<Image> {
+    public NoImageWithMissingSprite(
+      ViolationLevel level = ViolationLevel.Warning,
+      ViolationScope scope = ViolationScope.Both) : base(level, scope) {
+    }
+
+    public override List<IViolation> Handle(object thing) {
+      return this.Handle(thing as Image);
+    }
+
+    public override List<IViolation> Handle(Image thing) {
+      var violations = new List<IViolation>();
+
+      if (thing == null) {
+        return violations;
+      }
+
+      if (thing.sprite == null && thing.sprite.GetInstanceID() != 0)
+      {
+        violations.Add(new NoImageWithMissingSpriteViolation(this.Level, thing));
+      }
+
+      return violations;
+    }
+  }
+}
+#endif

--- a/StaticAnalysis/Violations/NoImageWithMissingSpriteViolation.cs
+++ b/StaticAnalysis/Violations/NoImageWithMissingSpriteViolation.cs
@@ -1,0 +1,35 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Mooble.StaticAnalysis.Violation {
+  public class NoImageWithMissingSpriteViolation : IViolation {
+    private Image image;
+
+    public NoImageWithMissingSpriteViolation(ViolationLevel level, Image image) {
+      this.Level = level;
+      this.image = image;
+    }
+
+    public ViolationLevel Level { get; set; }
+
+    public string FormatCLI() {
+      return string.Format(
+        "{2} {1}: Image {0} has a missing sprite reference.",
+        this.image.name,
+        Utility.FormatObjectPath(this.image.gameObject),
+        this.Level.ToString().ToUpper());
+    }
+
+    public string FormatEditor() {
+      return string.Format(
+        "Image {0} has a missing sprite reference.",
+        Utility.FormatPrimaryObject(this.image.name));
+    }
+
+    public UnityEngine.Object GetObject() {
+      return this.image.gameObject;
+    }
+  }
+}
+#endif


### PR DESCRIPTION
## Changes:
- Add NoImageWithMissingSprite rule and violation.

## Comments:
This rule detects when an `Image` component has been left on a scene or prefab with a missing sprite (e.g. when the sprite was deleted from the project without updating the game objects that use it).