### PR TITLE
Ignore scene root objects

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -13,6 +13,7 @@ namespace Mooble.Config
     };
 
     public string[] PrefabLocations;
+    public string[] IgnoredSceneRootObjectNames;
     public StaticAnalysisRuleConfig[] Rules;
 
     public static Config LoadFromFile(string fileName = null)

--- a/EditorExtensions/StaticAnalysisMenu.cs
+++ b/EditorExtensions/StaticAnalysisMenu.cs
@@ -36,6 +36,7 @@ namespace Mooble.EditorExtension {
       var sa = LoadStaticAnalysisRules(config);
 
       var violations = new Dictionary<Rule, List<IViolation>>();
+      HashSet<string> ignoredSceneObjectNames = new HashSet<string>(config.IgnoredSceneRootObjectNames);
 
       for (var i = 0; i < SceneManager.sceneCount; i++) {
         var scene = SceneManager.GetSceneAt(i);
@@ -43,6 +44,10 @@ namespace Mooble.EditorExtension {
         GameObject[] rootGameObjects = scene.GetRootGameObjects();
         for (var j = 0; j < rootGameObjects.Length; j++) {
           var obj = rootGameObjects[j];
+          if (ignoredSceneObjectNames.Contains(obj.name)) {
+            continue;
+          }
+
           violations = StaticAnalysis.MergeRuleViolationDictionary(violations, sa.Analyze(ViolationScope.Scene, obj));
         }
       }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Only rules listed in the `Rules` list will be run.
 
 #### Exclusions
 
+The `IgnoredSceneRootObjectNames` property at the root level of the `moobleconfig.json`
+file allows you to specify object names at the root level of scenes that should be ignored by Mooble.
+This can be useful if you need to ignore certain prefabs that are from, say, 3rd party plugins.
+
 The `Exclusions` list is to allow users to provide various types that the
 rule in question should _not_ run on. This type name must be qualified
 with the full namespace and the assembly it belongs to. For example, if you

--- a/StaticAnalysis/CLI.cs
+++ b/StaticAnalysis/CLI.cs
@@ -60,11 +60,12 @@ namespace Mooble.StaticAnalysis {
 
       var stringBuilder = new StringBuilder();
       bool foundError = false;
+      HashSet<string> ignoredSceneObjectNames = new HashSet<string>(config.IgnoredSceneRootObjectNames);
 
       foreach (var scene in scenes) {
-        stringBuilder.Append("\nAnalyzing scene: " + scene.name);
-
-        foreach (var root in scene.GetRootGameObjects()) {
+        if (ignoredSceneObjectNames.Contains(root.name)) {
+          stringBuilder.Append("\n  Ignoring root object in scene: " + root.name);
+        } else {
           stringBuilder.Append("\n  Analyzing root object in scene: " + root.name);
           Dictionary<Rule, List<IViolation>> violations = sa.Analyze(ViolationScope.Scene, root);
 


### PR DESCRIPTION
## Changes:
- a65f8b9 Add IgnoredSceneRootObjectNames property to config.
- 29520fc Update README.md to account for IgnoredSceneRootObjectNames

## Comments:
On our project, we had to add a 3rd party object at the root level of a scene. This made Mooble fail, and there was no way to ignore it, so I added this new configuration option.