### PR TITLE
Update CLI to read scene and prefab lists from config instead of accepting them as command line args

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -13,6 +13,7 @@ namespace Mooble.Config
     };
 
     public string[] PrefabLocations;
+    public string[] SceneLocations;
     public string[] IgnoredSceneRootObjectNames;
     public StaticAnalysisRuleConfig[] Rules;
 

--- a/StaticAnalysis/CLI.cs
+++ b/StaticAnalysis/CLI.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 
-using Com.Uken.Extensions;
-
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -17,17 +15,15 @@ namespace Mooble.StaticAnalysis {
     public static void RunPrefabAnalysis() {
       var config = Mooble.Config.Config.LoadFromFile();
 
-      var prefabPaths = AssetDatabase
-        .FindAssets("t:prefab", config.PrefabLocations)
-        .Map(guid => AssetDatabase.GUIDToAssetPath(guid));
+      var prefabGuids = AssetDatabase.FindAssets("t:prefab", config.PrefabLocations);
 
       var sa = new StaticAnalysisBuilder(config).Get();
 
       bool foundError = false;
       var stringBuilder = new StringBuilder();
 
-      for (var i = 0; i < prefabPaths.Count; i++) {
-        var path = prefabPaths[i];
+      foreach (var prefabGuid in prefabGuids) {
+        var path = AssetDatabase.GUIDToAssetPath(prefabGuid);
         var obj = AssetDatabase.LoadAssetAtPath<GameObject>(path);
         stringBuilder.Append("\nAnalyzing prefab: " + path);
 
@@ -36,7 +32,7 @@ namespace Mooble.StaticAnalysis {
         foundError = foundError || foundErrorThisTime;
       }
 
-      if (prefabPaths.Count == 0) {
+      if (prefabGuids.Length == 0) {
         stringBuilder.Append("No prefabs were analyzed.");
       }
 
@@ -89,15 +85,13 @@ namespace Mooble.StaticAnalysis {
     private static List<Scene> LoadScenesFromConfig(Mooble.Config.Config config) {
       var scenes = new List<Scene>();
 
-      var scenePaths = AssetDatabase
-        .FindAssets("t:scene", config.SceneLocations)
-        .Map(guid => AssetDatabase.GUIDToAssetPath(guid));
+      var sceneGuids = AssetDatabase.FindAssets("t:scene", config.SceneLocations);
 
-      foreach (string scenePath in scenePaths) {
+      foreach (var sceneGuid in sceneGuids) {
         Scene scene;
 
         try {
-          scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+          scene = EditorSceneManager.OpenScene(AssetDatabase.GUIDToAssetPath(sceneGuid), OpenSceneMode.Additive);
         } catch (System.ArgumentException) {
           continue;
         }

--- a/moobleconfig.json
+++ b/moobleconfig.json
@@ -2,6 +2,9 @@
   "PrefabLocations": [
     "Assets/Prefabs"
   ],
+  "SceneLocations": [
+    "Assets/Scenes"
+  ],
   "IgnoredSceneRootObjectNames": [
   ],
   "Rules": [


### PR DESCRIPTION
## Changes:
- Update CLI to read scene and prefab lists from config instead of accepting them as command line args.
- Update config to include a `SceneLocations` entry.

## Comments:
- This fixes an issue where the list of prefabs or scenes to analyze could be too long for the command line tool, which could cause it to crash.
- ⚠️ Note that this a breaking change. If you have workflows that currently depend on the command line tool, you will need to migrate the prefab and scene lists into the config json.
